### PR TITLE
[Fix] Stake spent amplification attack

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,13 @@ CCriticalSection cs_main;
 BlockMap mapBlockIndex;
 map<uint256, uint256> mapProofOfStake;
 set<pair<COutPoint, unsigned int> > setStakeSeen;
+// maps any spent outputs in the past maxreorgdepth blocks to the height it was spent
+// this means for incoming blocks, we can check that their stake output was not spent before
+// the incoming block tried to use it as a staking input. We can also prevent block spam
+// attacks because then we can check that either the staking input is available in the current
+// active chain, or the staking input was spent in the past 100 blocks after the height
+// of the incoming block.
+map<COutPoint, int> mapStakeSpent;
 map<unsigned int, unsigned int> mapHashedBlocks;
 CChain chainActive;
 CBlockIndex* pindexBestHeader = NULL;
@@ -2004,6 +2011,9 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
                 if (coins->vout.size() < out.n + 1)
                     coins->vout.resize(out.n + 1);
                 coins->vout[out.n] = undo.txout;
+
+                // erase the spent input
+                mapStakeSpent.erase(out);
             }
         }
     }
@@ -2234,7 +2244,23 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     if (fTxIndex)
         if (!pblocktree->WriteTxIndex(vPos))
             return state.Abort("Failed to write transaction index");
+	
+   // add new entries
+    for (const CTransaction tx: block.vtx) {
+	if (tx.IsCoinBase() || tx.IsZerocoinSpend())
+	    continue;
+	for (const CTxIn in: tx.vin) {
+	    mapStakeSpent.insert(std::make_pair(in.prevout, pindex->nHeight));
+	}
+    }
 
+     // delete old entries
+    for (auto it = mapStakeSpent.begin(); it != mapStakeSpent.end(); ++it) {
+	if (it->second < pindex->nHeight - Params().MaxReorganizationDepth()) {
+	    mapStakeSpent.erase(it->first);
+	}
+    }
+	
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
 
@@ -3337,6 +3363,59 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
     }
 
     int nHeight = pindex->nHeight;
+	
+    if (block.IsProofOfStake()) {
+        LOCK(cs_main);
+
+         CCoinsViewCache coins(pcoinsTip);
+
+         if (!coins.HaveInputs(block.vtx[1])) {
+
+             // the inputs are spent at the chain tip so we should look at the recently spent outputs
+            for (CTxIn in : block.vtx[1].vin) {
+                auto it = mapStakeSpent.find(in.prevout);
+                if (it == mapStakeSpent.end()) {
+                    return false;
+                }
+                if (it->second <= pindexPrev->nHeight) {
+                    return false;
+                }
+            }
+        }
+
+         // if this is on a fork
+        if (!chainActive.Contains(pindexPrev) && pindexPrev != NULL) {
+
+             // start at the block we're adding on to
+            CBlockIndex *last = pindexPrev;
+
+             // while that block is not on the main chain
+            while (!chainActive.Contains(last) && pindexPrev != NULL) {
+                CBlock bl;
+                ReadBlockFromDisk(bl, last);
+
+                 // loop through every spent input from said block
+                for (CTransaction t : bl.vtx) {
+                    for (CTxIn in: t.vin) {
+
+                         // loop through every spent input in the staking transaction of the new block
+                        for (CTxIn stakeIn : block.vtx[1].vin) {
+
+                             // if they spend the same input
+                            if (stakeIn.prevout == in.prevout) {
+
+                                 // reject the block
+                                return false;
+                            }
+                        }
+                    }
+                }
+
+                 // go to the parent block
+                last = pindexPrev->pprev;
+            }
+        }
+    }
 
     // Write block to history file
     try {


### PR DESCRIPTION
Recently several resource exhaustion attacks on PoS has been discovered.

- Vulnerability 1:

It is called "I Can't Believe it's not Stake" attack. It was introduced
while merging upstream headers first feature into PoS forks. It fills
a victims node memory until resources are exhausted and node may crash
due to out of memory condition. Codebase is not affected by it.

- Vulnerability 2:

It is called "Spent Stake" attack. It was discoverd while investigating
vulnerability #1 above. It works because block verification ensures that
the coin exists, but not that it is unspent. After forking of the main
chain the coinstake transaction is still validated against thei main
chain TxDB. It allows to generate arbitrary amount of apparent stake
and inject it into victims node. Codebase is fixed with this commit.

More information about attack vectors:

http://fc19.ifca.ai/preproceedings/180-preproceedings.pdf
https://medium.com/@dsl_uiuc/fake-stake-attacks-on-chain-based-proof-of-stake-cryptocurrencies-b8b05723f806

Working proof of concept reproducer:

https://github.com/initc3/i-cant-believe-its-not-stake

Credits to mbroemma @ Galilel Project for the fix