### PR TITLE
[Fix] Stake spent amplification attack fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,11 +50,18 @@ using namespace std;
  */
 
 CCriticalSection cs_main;
+CCriticalSection cs_mapstake;
 
 BlockMap mapBlockIndex;
 map<uint256, uint256> mapProofOfStake;
-map<COutPoint, int> mapStakeSpent;
 set<pair<COutPoint, unsigned int> > setStakeSeen;
+// maps any spent outputs in the past maxreorgdepth blocks to the height it was spent
+// this means for incoming blocks, we can check that their stake output was not spent before
+// the incoming block tried to use it as a staking input. We can also prevent block spam
+// attacks because then we can check that either the staking input is available in the current
+// active chain, or the staking input was spent in the past 100 blocks after the height
+// of the incoming block.
+map<COutPoint, int> mapStakeSpent;
 map<unsigned int, unsigned int> mapHashedBlocks;
 CChain chainActive;
 CBlockIndex* pindexBestHeader = NULL;
@@ -2005,8 +2012,13 @@ bool DisconnectBlock(CBlock& block, CValidationState& state, CBlockIndex* pindex
                 if (coins->vout.size() < out.n + 1)
                     coins->vout.resize(out.n + 1);
                 coins->vout[out.n] = undo.txout;
-				// erase the spent input
-		mapStakeSpent.erase(out);
+
+                {
+                    LOCK(cs_mapstake);
+
+                    // erase the spent input
+                    mapStakeSpent.erase(out);
+                }
             }
         }
     }
@@ -2237,34 +2249,30 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     if (fTxIndex)
         if (!pblocktree->WriteTxIndex(vPos))
             return state.Abort("Failed to write transaction index");
+	
+    {
+        LOCK(cs_mapstake);
 
-		
-		
-
-    // add new entries
-    for (const CTransaction tx: block.vtx) {
-        if (tx.IsCoinBase())
-            continue;
-        for (const CTxIn in: tx.vin) {
-            LogPrint("map", "mapStakeSpent: Insert %s | %u\n", in.prevout.ToString(), pindex->nHeight);
-            mapStakeSpent.insert(std::make_pair(in.prevout, pindex->nHeight));
+        // add new entries
+        for (const CTransaction tx: block.vtx) {
+            if (tx.IsCoinBase())
+                continue;
+            for (const CTxIn in: tx.vin) {
+                mapStakeSpent.insert(std::make_pair(in.prevout, pindex->nHeight));
+            }
         }
+
+        // delete old entries
+        for (auto it = mapStakeSpent.begin(); it != mapStakeSpent.end();) {
+            if (it->second < pindex->nHeight - Params().MaxReorganizationDepth()) {
+                it = mapStakeSpent.erase(it);
+            }
+            else {
+                it++;
+            }
+	}
     }
-
-
-    // delete old entries
-    for (auto it = mapStakeSpent.begin(); it != mapStakeSpent.end();) {
-        if (it->second < pindex->nHeight - Params().MaxReorganizationDepth()) {
-            LogPrint("map", "mapStakeSpent: Erase %s | %u\n", it->first.ToString(), it->second);
-            it = mapStakeSpent.erase(it);
-        }
-        else {
-            it++;
-        }
-    }
-
-
-
+	
     // add this block to the view's block chain
     view.SetBestBlock(pindex->GetBlockHash());
 
@@ -3367,16 +3375,16 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
     }
 
     int nHeight = pindex->nHeight;
-
 	
-	if (block.IsProofOfStake()) {
+    if (block.IsProofOfStake()) {
         LOCK(cs_main);
 
-        CCoinsViewCache coins(pcoinsTip);
+         CCoinsViewCache coins(pcoinsTip);
 
-        if (!coins.HaveInputs(block.vtx[1])) {
-            // the inputs are spent at the chain tip so we should look at the recently spent outputs
+         if (!coins.HaveInputs(block.vtx[1])) {
+              LOCK(cs_mapstake);
 
+             // the inputs are spent at the chain tip so we should look at the recently spent outputs
             for (CTxIn in : block.vtx[1].vin) {
                 auto it = mapStakeSpent.find(in.prevout);
                 if (it == mapStakeSpent.end()) {
@@ -3388,37 +3396,40 @@ bool AcceptBlock(CBlock& block, CValidationState& state, CBlockIndex** ppindex, 
             }
         }
 
-        // if this is on a fork
+         // if this is on a fork
         if (!chainActive.Contains(pindexPrev) && pindexPrev != NULL) {
-            // start at the block we're adding on to
+
+             // start at the block we're adding on to
             CBlockIndex *last = pindexPrev;
 
-            // while that block is not on the main chain
+             // while that block is not on the main chain
             while (!chainActive.Contains(last) && pindexPrev != NULL) {
                 CBlock bl;
                 ReadBlockFromDisk(bl, last);
-                // loop through every spent input from said block
+
+                 // loop through every spent input from said block
                 for (CTransaction t : bl.vtx) {
                     for (CTxIn in: t.vin) {
-                        // loop through every spent input in the staking transaction of the new block
+
+                         // loop through every spent input in the staking transaction of the new block
                         for (CTxIn stakeIn : block.vtx[1].vin) {
-                            // if they spend the same input
+
+                             // if they spend the same input
                             if (stakeIn.prevout == in.prevout) {
-                                // reject the block
+
+                                 // reject the block
                                 return false;
                             }
                         }
                     }
                 }
 
-
-                // go to the parent block
+                 // go to the parent block
                 last = pindexPrev->pprev;
             }
         }
-    }   
-	
-	
+    }
+
     // Write block to history file
     try {
         unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);


### PR DESCRIPTION
Last fix fixed spend stake amplification attack but has two issues:

1. It does no proper iteration through mapStakeSpent and erase of
   old entries will crash the wallet.

2. It doesn't use locks and crashes certain operations like chain
   reindexing.

Both fixed with this commit and with both commits the fix is working.